### PR TITLE
nullglob within git-crypt-keeper

### DIFF
--- a/Formula/git-crypt-keeper.rb
+++ b/Formula/git-crypt-keeper.rb
@@ -3,7 +3,7 @@ require 'formula'
 class GitCryptKeeper < Formula
   homepage 'https://github.com/goodeggs/homebrew-devops/'
   url 'https://github.com/goodeggs/homebrew-devops.git'
-  version '1.0.1'
+  version '1.0.2'
 
   def install
     bin.install 'git-crypt-keeper'

--- a/git-crypt-keeper
+++ b/git-crypt-keeper
@@ -2,6 +2,7 @@
 set -e
 set -o pipefail
 set -u
+shopt -s nullglob
 
 # requires awk, git, git-crypt, mktemp, openssl, tar, tr, xargs
 


### PR DESCRIPTION
fixes git-crypt-keeper unseal's cp -a if there are no visible files
in the base directory of a git-crypt repo.