### PR TITLE
M1 sslayer

### DIFF
--- a/Formula/sslayer.rb
+++ b/Formula/sslayer.rb
@@ -2,7 +2,7 @@ class Sslayer < Formula
   desc 'SSL-terminating reverse proxy for the Good Eggs ecosystem'
   homepage 'https://github.com/goodeggs/homebrew-delivery-eng'
   url 'https://github.com/goodeggs/homebrew-delivery-eng.git'
-  version '2.2.3'
+  version '2.2.4'
 
   depends_on 'dnsmasq'
   # we want to depend on the cask, but you can't from formula; depending on the formula is broken

--- a/sslayer
+++ b/sslayer
@@ -21,13 +21,14 @@ mark_last_setup() {
 }
 
 configure_dnsmasq() {
-  mkdir -p /usr/local/etc
-  mkdir -p /usr/local/etc/dnsmasq.d/
-  cat << EOF > /usr/local/etc/dnsmasq.conf
-conf-dir=/usr/local/etc/dnsmasq.d/,*.conf
+  brew_prefix=$(brew --prefix)
+  mkdir -p "$brew_prefix/etc"
+  mkdir -p "$brew_prefix/etc/dnsmasq.d/"
+  cat << EOF > "$brew_prefix/etc/dnsmasq.conf"
+conf-dir=$brew_prefix/etc/dnsmasq.d/,*.conf
 EOF
 
-  cat << EOF > /usr/local/etc/dnsmasq.d/goodeggs-dev.conf
+  cat << EOF > "$brew_prefix/etc/dnsmasq.d/goodeggs-dev.conf"
 address=/goodeggs.dev/127.0.0.1
 address=/goodeggs.test/127.0.0.1
 EOF


### PR DESCRIPTION
homebrew on M1 installs to `/opt/homebrew`, so our dnsmasq config wasn't working.